### PR TITLE
Support xterm 6 peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "typescript": "^5.7.3"
       },
       "peerDependencies": {
-        "@xterm/xterm": "^5.5.0"
+        "@xterm/xterm": "^5.5.0 || ^6.0.0"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "typescript": "^5.7.3"
   },
   "peerDependencies": {
-    "@xterm/xterm": "^5.5.0"
+    "@xterm/xterm": "^5.5.0 || ^6.0.0"
   },
   "jest": {
     "testEnvironment": "jsdom"


### PR DESCRIPTION
Adds support for `@xterm/xterm@6.0.0`

https://github.com/Qovery/react-xtermjs/issues/63